### PR TITLE
Support for gzipped input vcf file

### DIFF
--- a/bin/utils/extract_snps.py
+++ b/bin/utils/extract_snps.py
@@ -18,6 +18,8 @@ import sys
 import os
 import pysam
 import re
+import gzip
+
 
 def usage():
     print "This script was designed to extract informative SNPs information from two parental genotypes, and return the F1 genotype."
@@ -126,8 +128,11 @@ if __name__ == "__main__":
         print  >> sys.stderr, "Error: --filt"
         usage()
         sys.exit()
-
-    vcf_handle = open(vcfFile)
+    
+    if vcfFile.endswith('.gz') or vcfFile.endswith('.gzip'):
+        vcf_handle = gzip.open(vcfFile)
+    else:
+        vcf_handle = open(vcfFile)
 
     header = []
     samples = []


### PR DESCRIPTION
Hi there,

vcf files from Sanger are huge, so I made a small modification to the extract_snps.py file so that it supports gzipped files. Tested on Scientific Linux 6.9, but should work on any system supported by HiC-Pro.

Cheers!

Kai