### PR TITLE
Fix raw matrix search for iceing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -303,8 +303,7 @@ A ready-to-use container is available `here <https://zerkalo.curie.fr/partage/Hi
 
 .. code-block:: guess
 
-    singularity create -s 5000 hicpro_latest_ubuntu.img
-    sudo singularity -d bootstrap hicpro_latest_ubuntu.img MY_INSTALL_PATH/HiC-Pro/Singularity
+    sudo singularity build hicpro_latest_ubuntu.img MY_INSTALL_PATH/HiC-Pro/Singularity
 
 3- Run HiC-pro
 

--- a/Singularity
+++ b/Singularity
@@ -21,7 +21,7 @@ OSVersion: xenial
     
     # install anaconda
     if [ ! -d /usr/local/anaconda ]; then
-       wget https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh\
+       wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh \
        	    -O ~/anaconda.sh && \
 	    bash ~/anaconda.sh -b -p /usr/local/anaconda && \
 	    rm ~/anaconda.sh

--- a/Singularity
+++ b/Singularity
@@ -6,6 +6,9 @@ OSVersion: xenial
 %labels
     AUTHOR Nicolas Servant
 
+%pre
+    apt-get install -y debootstrap
+    
 %post
     apt-get install -y wget
     apt-get install -y gzip

--- a/scripts/ice_norm.sh
+++ b/scripts/ice_norm.sh
@@ -77,7 +77,8 @@ do
 
 	    if [[ $input_data_type == "mat" ]]
 	    then
-		input=$(find -L $IN_DIR/${RES_FILE_NAME}/ -maxdepth 1 -name "*.matrix" -name "*$bsize*")
+		# input=$(find -L $IN_DIR/${RES_FILE_NAME}/ -maxdepth 1 -name "*.matrix" -name "*$bsize*")
+		input=$(find -L $IN_DIR/${RES_FILE_NAME}/ -maxdepth 3 -name "*${bsize}.matrix*")
 		if [ ! -z $input ]; then
 		    cmd="${PYTHON_PATH}/python ${SCRIPTS}/ice --results_filename ${NORM_DIR}/${bsize}/${RES_FILE_NAME}_${bsize}_iced.matrix --filter_low_counts_perc ${FILTER_LOW_COUNT_PERC} --filter_high_counts_perc ${FILTER_HIGH_COUNT_PERC} --max_iter ${MAX_ITER} --eps ${EPS} --remove-all-zeros-loci --output-bias 1 --verbose 1 ${input} >> ${LDIR}/ice_${bsize}.log"
                     echo $cmd > ${LDIR}/ice_${bsize}.log


### PR DESCRIPTION
Without this fix no raw matrix is found. The command finishes but does not perform the iceing. Furthermore, "*$bsize*" is not precise enough. E.g. if you have binsizes of 10000 and 100000 the current find command will find the matrix from 10000 and 100000 if the search for 10000 is done as "10000" is a substring of "100000".