### PR TITLE
correct the order of legends and fix issue #262

### DIFF
--- a/scripts/bowtie_wrap.sh
+++ b/scripts/bowtie_wrap.sh
@@ -45,7 +45,7 @@ end_to_end_align()
     fi
     
     echo "##HiC-Pro mapping" > ${ldir}/${prefix}_bowtie2.log
-    cmd="${BOWTIE2_PATH}/bowtie2 ${BOWTIE2_GLOBAL_OPTIONS} --rg-id BMG --rg SM:${prefix} -p ${N_CPU} -x ${BOWTIE2_IDX} -U ${infile} 2>> ${ldir}/${prefix}_bowtie2.log"
+    cmd="${BOWTIE2_PATH}/bowtie2 ${BOWTIE2_GLOBAL_OPTIONS} --rg-id BMG --rg SM:${prefix} -p ${bwt_cpu} -x ${BOWTIE2_IDX} -U ${infile} 2>> ${ldir}/${prefix}_bowtie2.log"
     if [[ $filtunmap == 1 ]]; then
 	cmd=$cmd"| ${SAMTOOLS_PATH}/samtools view -F 4 -bS - > ${odir}/${prefix}_${REFERENCE_GENOME}.bwt2glob.bam"
     else
@@ -82,11 +82,19 @@ cut_and_align()
     if [[ $unmap == 1 ]]; then
 	BOWTIE2_LOCAL_OPTIONS=${BOWTIE2_LOCAL_OPTIONS}" --un ${odir}/${prefix}_${REFERENCE_GENOME}.bwt2glob.unmap.fastq"
     fi
+
+    ## Run bowtie
+    if [[ $N_CPU -lt 2 ]]; then
+    echo -e "Warning : HiC-Pro need at least 2 CPUs to run the mapping !!"
+    bwt_cpu=1
+    else
+    bwt_cpu=$(( $N_CPU / 2 ))
+    fi
     
     ## Run bowtie
     echo "##HiC-Pro mapping" > ${ldir}/${prefix}_bowtie2.log
 
-    cmd="${BOWTIE2_PATH}/bowtie2 ${BOWTIE2_LOCAL_OPTIONS} --rg-id BML --rg SM:${prefix} -p ${N_CPU} -x ${BOWTIE2_IDX} -U ${odir}/${tfile} 2>> ${ldir}/${prefix}_bowtie2.log | ${SAMTOOLS_PATH}/samtools view -bS - > ${odir}/${prefix}_bwt2loc.bam"
+    cmd="${BOWTIE2_PATH}/bowtie2 ${BOWTIE2_LOCAL_OPTIONS} --rg-id BML --rg SM:${prefix} -p ${bwt_cpu} -x ${BOWTIE2_IDX} -U ${odir}/${tfile} 2>> ${ldir}/${prefix}_bowtie2.log | ${SAMTOOLS_PATH}/samtools view -bS - > ${odir}/${prefix}_bwt2loc.bam"
     exec_cmd "$cmd" 
 }
 

--- a/scripts/plot_mapping_portion.R
+++ b/scripts/plot_mapping_portion.R
@@ -119,7 +119,7 @@ ploMapStat <- function(mat, sampleName="", tag="", legend=TRUE){
                       ggtitle(tit) + theme(plot.title = element_text(lineheight=.8, face="bold", size=8))
 
   if (legend){
-    gp = gp + scale_fill_manual(values=c("darkgray", sel.colours[2:4]), labels = c("Full read mapping (%)",  "Trimmed read Mapping (%)", "Aligned reads (%)", "Not aligned (%)")) + guides(fill=guide_legend(title="")) + theme(plot.margin=unit(x=c(1,0,0,0), units="cm"), legend.position="bottom", legend.text=element_text(size=5))
+    gp = gp + scale_fill_manual(values=c("darkgray", sel.colours[2:4]), labels = c("Not aligned (%)", "Full read mapping (%)",  "Trimmed read Mapping (%)", "Aligned reads (%)")) + guides(fill=guide_legend(title="")) + theme(plot.margin=unit(x=c(1,0,0,0), units="cm"), legend.position="bottom", legend.text=element_text(size=5))
   }else{
     gp = gp + scale_fill_manual(values=c("darkgray", sel.colours[2:4])) + theme(plot.margin=unit(c(1,0,1.45,0),"cm"))+ guides(fill=FALSE)
   }


### PR DESCRIPTION
It seems like the order of legends when plotting mapping portion should be ["Not aligned (%)", "Full read mapping (%)",  "Trimmed read Mapping (%)", "Aligned reads (%)"]