### PR TITLE
fq extension handling for inter-replicat

### DIFF
--- a/bin/HiC-Pro
+++ b/bin/HiC-Pro
@@ -247,7 +247,7 @@ fi
 
 ## Check rawdata structure
 if [[ $NEED_FASTQ == 1 ]]; then
-    nbin=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fastq" -o -name "*.fastq.gz" -o -name "*.fq.gz" | wc -l)
+    nbin=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fastq" -o -name "*.fastq.gz" -o -name "*.fq" -o -name "*.fq.gz" | wc -l) #!
     nbin_r1a=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fastq*" -and -name "*${PAIR1_EXT}*" | wc -l)
     nbin_r1b=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq*" -and -name "*${PAIR1_EXT}*" | wc -l)
     nbin_r2a=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fastq*" -and -name "*${PAIR2_EXT}*" | wc -l)
@@ -256,29 +256,87 @@ if [[ $NEED_FASTQ == 1 ]]; then
     nbin_r2=0
     let "nbin_r1 = nbin_r1a + nbin_r1b"
     let "nbin_r2 = nbin_r2a + nbin_r2b"
+    #echo "nbin_r1b = $nbin_r1b"
+	#echo "nbin_r1a = $nbin_r1a"
+	#echo "nbin_r1 = $nbin_r1"
+	#echo "nbin_r2b = $nbin_r2b"
+	#echo "nbin_r2a = $nbin_r2a"
+	#echo "nbin_r2 = $nbin_r2"
     if [ $nbin == 0 ]; then
 	die "Error: Directory Hierarchy of rawdata '$INPUT' is not correct. No '.fastq(.gz)' files detected"
     fi
     if [[ $nbin_r1 == 0 || $nbin_r2 == 0 || $nbin_r1 != $nbin_r2 ]]; then
         die "Error: Directory Hierarchy of rawdata '$INPUT' is not correct. Paired '.fastq' files with ${PAIR1_EXT}/${PAIR2_EXT} are required !"
     fi
-    if [[ $nbin_r1b != $nbin_r2b ]]
+    if [[ $nbin_r1b != $nbin_r2b || $nbin_r1a != $nbin_r2a ]] #! Intra sample
     then
         echo "Your fastq files doesn't have the same extension !"
         if [[ $nbin_r1b == 1 && $nbin_r1a == 0 ]]
         then
-            old_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq*" -and -name "*${PAIR1_EXT}*")
-            new_name=$(echo $old_name | sed -e "s/\.fq.gz$/.fastq.gz/")
-            echo "Renaming $old_name in $new_name"
-            mv $old_name $new_name
+            with_gz_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq.gz" -and -name "*${PAIR1_EXT}*")
+            without_gz_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq" -and -name "*${PAIR1_EXT}*")
+            #echo "with_gz_name: $with_gz_name"
+			#echo "without_gz_name: $without_gz_name"
+            if [[ -z $with_gz_name && -r $without_gz_name ]] #if nbin_r1b doesn't have gz extension, so if it is a .fq
+            then
+            	new_name=$(echo $without_gz_name | sed -e "s/\.fq$/.fastq/") #!
+            	echo "Renaming $old_name in $new_name"
+            	mv $without_gz_name $new_name
+            elif [[ -z $without_gz_name && -r $with_gz_name ]]
+            then
+            	new_name=$(echo $with_gz_name | sed -e "s/\.fq.gz$/.fastq.gz/") #!
+            	echo "Renaming $old_name in $new_name"
+            	mv $with_gz_name $new_name
+            fi	
         elif [[ $nbin_r2b == 1 && $nbin_r2a == 0 ]]
         then
-            old_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq*" -and -name "*${PAIR2_EXT}*")
-            new_name=$(echo $old_name | sed -e "s/\.fq.gz$/.fastq.gz/")
-            echo "Renaminf $old_name in $new_name"
-            mv $old_name $new_name
-        fi
-    fi
+            with_gz_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq.gz" -and -name "*${PAIR2_EXT}*")
+            without_gz_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq" -and -name "*${PAIR2_EXT}*")
+            #echo "with_gz_name: $with_gz_name"
+			#echo "without_gz_name: $without_gz_name"
+            if [[ -z $with_gz_name && -r $without_gz_name ]]
+            then
+            	new_name=$(echo $without_gz_name | sed -e "s/\.fq$/.fastq/") #!
+            	echo "Renaming $old_name in $new_name"
+            	mv $without_gz_name $new_name
+            elif [[ -z $without_gz_name && -r $with_gz_name ]]
+            then
+            	new_name=$(echo $with_gz_name | sed -e "s/\.fq.gz$/.fastq.gz/") #!
+            	echo "Renaming $old_name in $new_name"
+            	mv $with_gz_name $new_name
+            fi
+		fi	
+	elif [[ $nbin_r1b == $nbin_r2b && $nbin_r1a == $nbin_r2a ]] #! Inter Sample
+	then
+		if [[ $nbin_r1 -gt 1 && $nbin_r2 -gt 1 ]] #If we really have multiple samples
+		then
+			tab_ext=(${PAIR1_EXT} ${PAIR2_EXT})
+			for i in `seq 0 1`;
+			do
+            	with_gz_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq.gz" -and -name "*${tab_ext[$i]}*")
+            	without_gz_name=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.fq" -and -name "*${tab_ext[$i]}*")
+            	#echo "with_gz_name_r1: $with_gz_name"
+				#echo "without_gz_name_r1: $without_gz_name"
+            	if [[ -z $with_gz_name && -r $without_gz_name ]]
+            	then
+					for i in $without_gz_name
+					do
+            			new_name=$(echo $i | sed -e "s/\.fq$/.fastq/") #!
+            			echo "Renaming $i in $new_name"
+            			mv $i $new_name
+					done
+            	elif [[ -z $without_gz_name && -r $with_gz_name ]]
+            	then
+					for i in $with_gz_name
+					do
+            			new_name=$(echo $i | sed -e "s/\.fq.gz$/.fastq.gz/") #!
+            			echo "Renaming $i in $new_name"
+            			mv $i $new_name
+					done
+            	fi
+			done
+		fi
+	fi
 
 elif [[ $NEED_BAM == 1 ]]; then
     nbin=$(find -L $INPUT -mindepth 2 -maxdepth 2 -name "*.bam" | wc -l)
@@ -339,8 +397,8 @@ cd $OUTPUT
 #####################
 
 if [[ $NEED_FASTQ == 1 ]]; then
-    r1files=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.fastq" -o -name "*.fastq.gz" -o -name "*.fq.gz" | grep "$PAIR1_EXT" | wc -l)
-    r2files=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.fastq" -o -name "*.fastq.gz" -o -name "*.fq.gz" | grep "$PAIR2_EXT" | wc -l)
+    r1files=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.fastq" -o -name "*.fastq.gz" -o -name "*.fq.gz" -o -name "*.fq" | grep "$PAIR1_EXT" | wc -l) #!
+    r2files=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.fastq" -o -name "*.fastq.gz" -o -name "*.fq.gz" -o -name "*.fq" | grep "$PAIR2_EXT" | wc -l) #!
     if [[ "$r1files" != "$r2files" ]]; then
 	die "Number of $PAIR1_EXT files is different from $PAIR2_EXT [$r1files vs $r2files]. \
 Please, note that the paired-end files are detected using the PAIR1_EXT/PAIR2_EXT parameters. Be sure that there is no conflict with files/dir names."

--- a/scripts/hic.inc.sh
+++ b/scripts/hic.inc.sh
@@ -135,7 +135,7 @@ get_data_type()
 {
     ## return the highest possible input files type
     nb_fqa=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.fastq" -o -name "*.fastq.gz" | wc -l)
-    nb_fqb=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.fq.gz" | wc -l)
+    nb_fqb=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.fq" -o -name "*.fq.gz" | wc -l) #!
     nb_bam=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.bam" -o -name "*.sam" | wc -l)
     nb_vpairs=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.validPairs" | wc -l)
     nb_allvpairs=$(find -L $RAW_DIR -mindepth 2 -maxdepth 2 -name "*.allValidPairs" | wc -l)
@@ -154,7 +154,7 @@ get_data_type()
     elif (( $nb_fqb > 0 )); then
         INPUT_DATA_TYPE="fq"
     else
-	die "Error in input type.'.fastq|.bam|.validPairs|.allValidPairs|.matrix' files are expected."
+	die "Error in input type.'.fastq|.fq|.bam|.validPairs|.allValidPairs|.matrix' files are expected." #!
     fi
     echo $INPUT_DATA_TYPE
 }
@@ -167,7 +167,7 @@ set_ext2fastq()
 {
     local file=$1
     local ext=$2
-    file=$(echo $file | sed -e "s/\.fastq$//" -e "s/\.fastq.gz$//" -e "s/\.fq.gz$//")
+    file=$(echo $file | sed -e "s/\.fastq$//" -e "s/\.fastq.gz$//" -e "s/\.fq$//" -e "s/\.fq.gz$//") #!
     echo ${file}${ext}
 }
 
@@ -231,7 +231,7 @@ get_fastq_for_bowtie_global()
         ifastq=$(get_hic_files $RAW_DIR .fastq | grep "$PAIR1_EXT")
     elif [[ $input_data_type == "fq" ]]
     then
-        ifastq=$(get_hic_files $RAW_DIR .fq.gz | grep "$PAIR1_EXT")
+        ifastq=$(get_hic_files $RAW_DIR .fq | grep "$PAIR1_EXT") #!
     fi
     echo $ifastq
 }


### PR DESCRIPTION
Handling of : 

- fq/fq.gz extension between replicates
- fq/fq-gz extension inside replicates

Replicates can have different extension between them, e.g : fq, fq.gz, fastq, fastq.gz
Nonetheless, inside a replicate, the two read file (R1 and R2) can have different extensions (fastq/fq or fastq.gz/fq.gz) but must be both decompressed or compressed.