### PR TITLE
Change Ligation Site in hicpro-config.txt

### DIFF
--- a/config-hicpro.txt
+++ b/config-hicpro.txt
@@ -65,7 +65,7 @@ REPORT_CAPTURE_REPORTER = 1
 #######################################################################
 
 GENOME_FRAGMENT = HindIII_resfrag_hg19.bed
-LIGATION_SITE = AAGCTAGCTT
+LIGATION_SITE = A^GATCT
 MIN_FRAG_SIZE = 
 MAX_FRAG_SIZE =
 MIN_INSERT_SIZE =


### PR DESCRIPTION
Hi,

Using the existing ligation site in the example template causes the following error when calling `digest_genome.py`. 

```
Unable to detect offset for AAGCTAGCTT. Please, use '^' to specify the cutting position,
                   i.e A^GATCT for HindIII digestion.
```

This change corrects that error.