### PR TITLE
improvement: replaces run with entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,5 @@ RUN cd /tmp && \
     cd .. && \
     rm -fr HiC-Pro*
 
-RUN /HiC-Pro_3.1.0/bin/HiC-Pro -h
+ENTRYPOINT /HiC-Pro_3.1.0/bin/HiC-Pro
+CMD ["-h"]


### PR DESCRIPTION
Hi @nservant,

Thanks for the great package! When I was setting up with Docker, I realized you use a run command—I'd highly recommend creating a default `ENTRYPOINT` and then default arguments to be passed to that entrypoint with `CMD`. This way, users can use the tool out of the box without having to jump inside the container or add extraneous arguments to the `docker` call.

**Old Output**

```
> docker run nservant/hicpro
>
```

(nothing is printed to the screen)

**New output**

```
> docker run nservant/hicpro
usage : HiC-Pro -i INPUT -o OUTPUT -c CONFIG [-s ANALYSIS_STEP] [-p] [-h] [-v]
Use option -h|--help for more information
```

