### PR TITLE
Update make_viewpoints.py to convert exclusionSize to int

### DIFF
--- a/bin/utils/make_viewpoints.py
+++ b/bin/utils/make_viewpoints.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
         elif opt in ("-t", "--targetFile"):
             targetFile = arg
         elif opt in ("-e", "--exclusion"):
-            exclusionSize = arg
+            exclusionSize = int(arg)
         elif opt in ("-o", "--oprefix"):
             oprefix = arg
         elif opt in ("-c", "--cis"):


### PR DESCRIPTION
To address the error when passing -e :
> TypeError: '>' not supported between instances of 'str' and 'int'

This patch can solve the same issue: https://github.com/nservant/HiC-Pro/issues/402