### PR TITLE
reformat print line to get rid off unwanted spaces

### DIFF
--- a/bin/utils/extract_snps.py
+++ b/bin/utils/extract_snps.py
@@ -313,9 +313,11 @@ if __name__ == "__main__":
                         snp_counter += 1
                         #altg[0]="1/1"
                         ##print chrom + "\t" + fields[1] + "\t" + fields[2] + "\t" + geno[0] + "\t" + geno[1] + "\t" + fields[5] + "\t" + fields[6] + "\t" + fields[7] + "\t" + fields[8] + "\t" + ":".join(altg)
-                        print("{}\t{}\t{}\t{}\t{}\
-                              \t{}\t{}\t{}\tGT\t0|1".format(chrom, fields[1], fields[2],\
-                                                            geno[0], geno[1], fields[5], fields[6], fields[7]))
+                        print(
+                            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\tGT\t0|1".format(
+                                chrom, fields[1], fields[2],geno[0], geno[1], fields[5], fields[6], fields[7]
+                            )
+                        )
 
                 else:
                     badqual_counter += 1


### PR DESCRIPTION
Hi, Thanks for the software !
I've noticed that the extract_snps script introduces spaces directly after the geno[1] field, at the position where the print line is split up over multiple lines. This causes issues in the assignment later on as no reads can be assigned to the alternative genotype. The pipeline fails later in the matrix generation.

Reformatting this line gets rid of the spaces and fixes the issues downstream.

I've tested with [mgp_REL2021_snps.vcf.gz](https://ftp.ebi.ac.uk/pub/databases/mousegenomes/REL-2112-v8-SNPs_Indels/mgp_REL2021_snps.vcf.gz), corresponding to GRCm39. 

Related to #572.

Kind regards,

WardDeb